### PR TITLE
Update run.sh and Readme to support wildcard (*) names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Variable | Default value | Description
 **LOGINNAME** | myusername | Your TransIP username
 **PRIVATEKEY** | myprivatekey | The private key from the key-pair generated at the TransIP API settings. See run example above when the key is stored in a file named 'private.key'
 **DOMAIN** | mydomain.com | The domainname registered at TransIP from which you want to update a record
-RECORD | @ | The DNS record name for which to change the IP address (@, *, www, etc.)
+RECORD | @ | The DNS record name for which to change the IP address (@, www, etc.). For wildcard (*) use 'wildcard'.
 TTL | 300 | The Time-To-Live of the DNS record, defaults to 5 minutes
 TYPE | A | The type of the record to update
 INTERVAL | 300 | The interval in seconds before checking again if the public IP has changed

--- a/run.sh
+++ b/run.sh
@@ -24,8 +24,13 @@ do
     # Check if IP has changed
     if [ "$CurrentIP" != "$LastSet" ]; then
         
-        # Update DNS record
-        ./tipctl.phar domain:dns:updatednsentry $DOMAIN $RECORD $TTL $TYPE $CurrentIP
+        # Set the DNS entry value
+        if [[ "$RECORD" == "wildcard" ]]; then
+            ./tipctl.phar domain:dns:updatednsentry $DOMAIN '*' $TTL $TYPE $CurrentIP
+        else
+            ./tipctl.phar domain:dns:updatednsentry $DOMAIN $RECORD $TTL $TYPE $CurrentIP
+        fi
+
         if [ $? == 0 ]; then
 
             # IP has been set


### PR DESCRIPTION
The wildcard character * can not be used as an environment variable. I wanted to use it anyway. If you think this adds and want to incorporate it please do. If I made a mistake and the * can be used in some other way (with docker compose) you can close this (and please let me know).
Thanks